### PR TITLE
Expose seek in midi file Player, small MidiRouter cleanup

### DIFF
--- a/NFluidsynth/MidiRouter.cs
+++ b/NFluidsynth/MidiRouter.cs
@@ -38,16 +38,19 @@ namespace NFluidsynth
 
         public void SetDefaultRules()
         {
+            ThrowIfDisposed();
             LibFluidsynth.fluid_midi_router_set_default_rules(Handle);
         }
 
         public void ClearRules()
         {
+            ThrowIfDisposed();
             LibFluidsynth.fluid_midi_router_clear_rules(Handle);
         }
 
         public void AddRule(MidiRouterRule rule, FluidMidiRouterRuleType type)
         {
+            ThrowIfDisposed();
             LibFluidsynth.fluid_midi_router_add_rule(Handle, rule.Handle, type);
         }
     }

--- a/NFluidsynth/Player.cs
+++ b/NFluidsynth/Player.cs
@@ -74,6 +74,12 @@ namespace NFluidsynth
             ThrowIfDisposed();
             LibFluidsynth.fluid_player_set_loop(Handle, loop);
         }
+        
+        public void Seek(int tick)
+        {
+            ThrowIfDisposed();
+            LibFluidsynth.fluid_player_seek(Handle, tick);
+        }
 
         [Obsolete("Use " + nameof(MidiTempo) + " property instead.")]
         public void SetTempo(int tempo)


### PR DESCRIPTION
Exposes the seek method in player, calls `ThrowIfDisposed` in MidiRouter methods.